### PR TITLE
Resolves safari vendor style issues

### DIFF
--- a/src/components/CardLink.js
+++ b/src/components/CardLink.js
@@ -64,7 +64,10 @@ export default function CardLink(props) {
               height: "200%",
               transform: "rotate(-49deg) translate(0,75%)",
               transformOrigin: "30% center",
-              transition: "transform 0"
+              transition: "transform 0",
+              '@media not all and (min-resolution:.001dpcm)': {
+                display: 'none',
+              },
             }}
           />
         }

--- a/src/components/Minihacks.js
+++ b/src/components/Minihacks.js
@@ -24,15 +24,11 @@ export default function Minihacks() {
           border: `1px solid ${isDarkTheme ? theme.palette.primary.main : "#228eb9"}30`,
           borderRadius: theme.spacing(4),
           display: "block",
-          mixBlendMode: "color-burn",
           overflow: "hidden",
           padding: theme.spacing(4),
           transform: "translateY(0)",
           transition: "all 0.25s ease-in-out",
           backdropFilter: "blur(16px)",
-          '@media not all and (min-resolution:.001dpcm)': {
-            mixBlendMode: 'normal',
-          },
         }}
       >
         <Grid container spacing={6}>

--- a/src/components/Minihacks.js
+++ b/src/components/Minihacks.js
@@ -30,6 +30,9 @@ export default function Minihacks() {
           transform: "translateY(0)",
           transition: "all 0.25s ease-in-out",
           backdropFilter: "blur(16px)",
+          '@media not all and (min-resolution:.001dpcm)': {
+            mixBlendMode: 'normal',
+          },
         }}
       >
         <Grid container spacing={6}>

--- a/src/components/Showcase.js
+++ b/src/components/Showcase.js
@@ -47,14 +47,10 @@ export default function Showcase() {
           position: "absolute",
           left: "-15vw",
           maxWidth: theme.breakpoints.values.xl,
-          mixBlendMode: "overlay",
           opacity: 0.15,
           overflow: "hidden",
           top: "-30vh",
           zIndex: -1,
-          '@media not all and (min-resolution:.001dpcm)': {
-            mixBlendMode: 'normal',
-          },
           "& img": {
             width: "120vw",
           },

--- a/src/components/Showcase.js
+++ b/src/components/Showcase.js
@@ -52,6 +52,9 @@ export default function Showcase() {
           overflow: "hidden",
           top: "-30vh",
           zIndex: -1,
+          '@media not all and (min-resolution:.001dpcm)': {
+            mixBlendMode: 'normal',
+          },
           "& img": {
             width: "120vw",
           },


### PR DESCRIPTION
I forgot that safari does not elegantly handle specific mixBlendMode values, so I've added browser backup conditional styles.

https://documentation-git-main-polywrap.vercel.app/