### PR TITLE
fixed two bugs in snippets-inject.ts

### DIFF
--- a/scripts/snippets-inject.ts
+++ b/scripts/snippets-inject.ts
@@ -73,13 +73,13 @@ async function injectSnippetIntoFile(
     }
 
     contents = contents.replace(
-      `${marker}${name}`,
-      snippets[name]
+      `${marker}${name}\n`,
+      `${snippets[name]}\n`
     );
     console.log("- Inject Snippet", name, "into", filePath);
 
     modified = true;
-    index = nameStartIdx + snippets[name].length;
+    index = markerIdx + snippets[name].length;
   }
 
   if (modified) {


### PR DESCRIPTION
This PR contains two small fixes to snippets-inject, allowing the algorithm to correctly find and replace snippet markers that have similar names or are close to each other.