### PR TITLE
Added docs for infra pipeline and test-env-js package; updated other docs

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -37,7 +37,6 @@ module.exports = {
             'quick-start/create-wasm-wrappers/adding-new-functions',
             'quick-start/create-wasm-wrappers/writing-tests-with-workflows',
             'quick-start/create-wasm-wrappers/deploy-locally-and-test',
-            'quick-start/create-wasm-wrappers/end-to-end-test',
             'quick-start/create-wasm-wrappers/default-plugins',
             'quick-start/create-wasm-wrappers/adding-metadata',
             'quick-start/create-wasm-wrappers/uniswapv3-to-polywrap',
@@ -47,6 +46,7 @@ module.exports = {
           type: 'category',
           label: 'Test Wasm Wrappers',
           items: [
+            'quick-start/test-wasm-wrappers/end-to-end-test',
             'quick-start/test-wasm-wrappers/infra-pipeline',
           ],
         },
@@ -109,12 +109,13 @@ module.exports = {
                   label: 'Libraries',
                   items: [
                     'reference/clients/js/libraries/react',
+                    'reference/clients/js/libraries/test-env-js'
                   ]
                 }
               ]
             }
           ]
-        }
+        },
       ]
     },
     /*{

--- a/sidebars.js
+++ b/sidebars.js
@@ -39,7 +39,7 @@ module.exports = {
             'quick-start/create-wasm-wrappers/deploy-locally-and-test',
             'quick-start/create-wasm-wrappers/default-plugins',
             'quick-start/create-wasm-wrappers/adding-metadata',
-            'quick-start/create-wasm-wrappers/uniswapv3-to-polywrap',
+            // 'quick-start/create-wasm-wrappers/uniswapv3-to-polywrap',
           ],
         },
         {

--- a/sidebars.js
+++ b/sidebars.js
@@ -45,6 +45,13 @@ module.exports = {
         },
         {
           type: 'category',
+          label: 'Test Wasm Wrappers',
+          items: [
+            'quick-start/test-wasm-wrappers/infra-pipeline',
+          ],
+        },
+        {
+          type: 'category',
           label: 'Build & Deploy Wasm Wrappers',
           items: [
             'quick-start/build-and-deploy-wasm-wrappers/build-pipeline',

--- a/snippets/as/simple-storage/polywrap.meta.yaml
+++ b/snippets/as/simple-storage/polywrap.meta.yaml
@@ -5,6 +5,9 @@ subtext: Simple Storage on Ethereum
 description: Set and get a value on an Ethereum smart contract using Polywrap.
 repository: https://github.com/polywrap/demos
 icon: ./meta/icon.png
+tags:
+  - simple
+  - polywrap
 links:
   - name: dApp
     icon: ./meta/link.svg

--- a/src/docs/quick-start/create-wasm-wrappers/adding-metadata.md
+++ b/src/docs/quick-start/create-wasm-wrappers/adding-metadata.md
@@ -3,7 +3,10 @@ id: 'adding-metadata'
 title: 'Adding Metadata'
 ---
 
-Wrapper developers can add metadata to their wrappers by writing a Meta Manifest file named `polywrap.meta.yaml`.
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Developers can add metadata to their wrappers by writing a Meta Manifest `polywrap.meta.yaml` file.
 Metadata makes it easier for application developers to display a wrapper, make it searchable, and find helpful links.
 
 ## Declaration
@@ -16,34 +19,36 @@ meta: ./polywrap.meta.yaml
 
 ## Content
 
-The content of a Meta Manifest can be represented in pseudocode as an interface with the fields that can 
-(or must) be populated in the manifest file. Here we represent the manifest as a TypeScript interface, with explanatory 
-comments next to each property.
+The Meta Manifest contains titles, descriptions, images, tags, and links that application developers can display
+when presenting or discussing your wrapper.
 
-```typescript title="Meta Manifest represented as TypeScript object"
-interface MetaManifest {
-  format: "0.0.1-prealpha.3"; // determines which fields are expected or required.
-  displayName?: string; // name of the wrapper that users should use for presentation
-  subtext?: string; // subtext of display name; brief description of the wrapper
-  description?: string; // full description of the wrapper
-  repository?: string; // repository URL
-  tags?: string[]; // terms that can help find your wrapper in search
-  icon?: string; // path to wrapper icon or logo
-  links?: { // links relevant to your wrapper
-    name: string; // name of link
-    icon?: string; // icon associated with link
-    url: string; // link URL
-  }[];
-}
+<Tabs
+defaultValue="schema"
+values={[
+{label: 'Schema', value: 'schema'},
+{label: 'Example', value: 'example'},
+]}>
+<TabItem value="schema">
+
+```yaml
+format: # The manifest format version
+displayName: # (Optional) Name of the wrapper that users should use for presentation
+subtext: # (Optional) Subtext of display name; brief description of the wrapper
+description: # (Optional) Detailed description
+repository: # (Optional) Repository URL
+icon: # (Optional) Path to wrapper icon or log
+tags: # (Optional) Array of terms that can help find your wrapper in search
+links: # (Optional) Array of links relevant to your wrapper
+  - name: # Name of link
+    icon: # (Optional) Icon associated with link
+    url: # (Optional) Link URL
 ```
 
-Most fields of the Meta Manifest are optional. 
-The required fields (indicated in the TypeScript example above with *?* symbols) are as follows:
-* format
-* If a link is specified, the name of the link and its URL are required
-
-## Example
+</TabItem>
+<TabItem value="example">
 
 ```yaml title="Fully configured Meta Manifest"
 $snippet: yaml-simple-storage-meta-manifest
 ```
+</TabItem>
+</Tabs>

--- a/src/docs/quick-start/create-wasm-wrappers/default-plugins.md
+++ b/src/docs/quick-start/create-wasm-wrappers/default-plugins.md
@@ -3,7 +3,6 @@ id: default-plugins
 title: Default plugins
 ---
 
-## Default Plugins
 Polywrap plugin wrappers extend the capabilities of Wasm wrappers. Some plugin wrappers come included in the Polywrap client by default:
 
 - ENS Resolver

--- a/src/docs/quick-start/test-wasm-wrappers/end-to-end-test.md
+++ b/src/docs/quick-start/test-wasm-wrappers/end-to-end-test.md
@@ -28,9 +28,9 @@ As more Polywrap Clients are released in various languages, implementing plugin 
 
 You'll need the following installed as developer dependencies before testing your wrapper:
 
-- [polywrap](../../reference/cli/polywrap-cli)
-- `@polywrap/test-env-js`
-- [@polywrap/client-js](../../reference/clients/js/client-js)
+- [`polywrap`](../../reference/cli/polywrap-cli)
+- [`@polywrap/test-env-js`](../../reference/clients/js/libraries/test-env-js)
+- [`@polywrap/client-js`](../../reference/clients/js/client-js)
 - `jest`
 - `@types/jest`
 
@@ -47,41 +47,19 @@ yarn add -D polywrap @polywrap/test-env-js @polywrap/client-js jest @types/jest
 A Polywrap test environment is most useful when it integrates an IPFS node and an Ethereum test network, so that incomplete 
 wrappers can be deployed and queried on your local machine.
 
-The Polywrap CLI can be used to start a Polywrap-ready test environment:
+The Polywrap CLI can be used to start a Polywrap-ready test environment.
+See [Configure Polywrap infrastructure pipeline](./infra-pipeline) for more information.
 
-```shell
-npx polywrap infra up --modules=eth-ens-ipfs
-```
-
-The CLI can also be used to stop the test environment:
-
-```shell
-npx polywrap infra down --modules=eth-ens-ipfs
-```
-
-The test environment is a docker container with:
-- A test server at **http://localhost:4040**
-- A standard Ganache Ethereum test network at **http://localhost:8545**
-- An IPFS node at **http://localhost:5001**
-
-It also sets up an ENS contract at initialization, so you can build wrappers and deploy them to an ENS URI on your locally hosted testnet.
-
-However, this guide will use the `@polywrap/test-env-js` package instead. The `@polywrap/test-env-js` can be used to start 
-and stop this same test environment programmatically.
-:::
+This guide will use the [`@polywrap/test-env-js`](../../reference/clients/libraries/test-env-js) package.
+The `@polywrap/test-env-js` package uses the default infrastructure module included with the [`polywrap`](../../reference/cli/polywrap-cli) CLI as a standard test environment.
+We can use `@polywrap/test-env-js` to start and stop the test environment programmatically.
 
 ## **Starting and stopping a Polywrap Test environment with @polywrap/test-env-js**
 
-The `@polywrap/test-env-js` package includes functions for starting and stopping a Polywrap test environment.
+If you're unfamiliar with [`@polywrap/test-env-js`](../../reference/clients/libraries/test-env-js), feel free to check 
+out the reference documentation before we continue.
 
-The `initTestEnvironment` function takes no arguments starts a local test environment.
-
-The `stopTestEnvironment` function takes no arguments and tears down a test environment if one is running.
-
-The package also exports a `providers` object with URIs for our local ethereum network provider and IPFS provider,
-as well as an `ensAddresses` object containing the Ethereum address of our locally-deployed ENS registry smart contract.
-
-To see these in action, let's start a new file where we will write our first test. Like many testing frameworks in
+Let's start a new file where we will write our first test. Like many testing frameworks in
 JavaScript, the Jest framework includes hooks that run before and after all tests. I've added a call to `initTestEnvironment`
 in the `beforeAll` hook, so we can start our test environment before running our tests. I added a call to `stopTestEnvironment` 
 in the `afterAll` hook to make sure the test environment does not continue running on our system after we finish testing.
@@ -93,12 +71,7 @@ $snippet: js-e2e-test-init
 ## **Building and deploying a Wasm wrapper for testing with @polywrap/test-env-js**
 
 To invoke a Wasm wrapper in a test, we first need to build and deploy it. We can do this with `@polywrap/test-env-js` using
-the `buildAndDeployWrapper` function. The `buildAndDeployWrapper` function requires an absolute path to the directory of 
-your wrapper project that contains the `polywrap.yaml` manifest file, the values that were returned by `initTestEnvironment`, 
-and optionally an ENS domain name.
-
-The `buildAndDeployWrapper` function returns an ENS domain name and an IPFS CID. Either of these outputs can be used to call
-your wrapper. If an ENS domain name was not provided when calling `buildAndDeployWrapper`, a name will be randomly selected for you.
+the `buildAndDeployWrapper` function. 
 
 Here we obtain the absolute path to our wrapper project in three steps. First we get the directory of the folder containing
 our test script, using the node.js `__dirname` global variable. We then append the path from our test script file to the
@@ -188,11 +161,8 @@ $snippet: js-e2e-test-deploy
 Since we are using TypeScript, we will want types to work with. It is possible to automatically generate TypeScript
 types from a GraphQL schema using the Polywrap CLI's `app` command. 
 
-Let's set up a `polywrap.app.yaml` manifest in a new folder called `types`.
-
-Before building our wrapper, we have a GraphQL schema for each of our modules. The `app` command is intended to be used 
-with built wrappers, which have only one schema. We will provide the manifest with the path to the composed schema in 
-our build folder. This means we need to build our wrapper before running tests.
+Let's set up a `polywrap.app.yaml` manifest in a new folder called `types`. 
+We will provide the manifest with the path to the composed schema in our build folder.
 
 ```yaml title="polywrap.app.yaml"
 $start: yaml-e2e-test-app-manifest

--- a/src/docs/quick-start/test-wasm-wrappers/infra-pipeline.md
+++ b/src/docs/quick-start/test-wasm-wrappers/infra-pipeline.md
@@ -1,0 +1,124 @@
+---
+id: infra-pipeline
+title: 'Configure Polywrap infrastructure pipeline'
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+The Polywrap CLI [`infra`](../../reference/cli/commands/deploy) command interacts with an Infra Manfiest 
+`polywrap.infra.yaml` file to to help users manage local infrastructure for their wrappers.
+The Infra Manifest declares environmental variables and infrastructure modules that describe the locations of 
+local, remote, or default [docker-compose](https://docs.docker.com/compose/compose-file/) files. 
+The Polywrap CLI [`infra`](../../reference/cli/commands/deploy) command reads the manifest and launches or halts
+modules as directed by the user.
+
+## Declaration
+
+Unlike some manifests, the Infra manifest does not need to be declared in your Polywrap manifest.
+
+## Content
+
+The Infra manifest consists of environmental variable declarations and one or more infrastructure modules. 
+Each module points to a local, remote, or default docker-compose file.
+
+<Tabs
+defaultValue="schema"
+values={[
+{label: 'Schema', value: 'schema'},
+{label: 'Example', value: 'example'},
+]}>
+<TabItem value="schema">
+
+```yaml
+format: # The manifest format version
+env: # Declare environmental variables here
+modules:
+  myRemote: # A remote package with a docker-compose file
+    package: # Package name
+    version: # Package version
+    registry: # Package registry name
+    dockerComposePath: # (Optional) Path to docker-compose file in the package directory
+  myLocal: # A local package with a docker-compose file
+    path: # Path to the package
+  eth-ens-ipfs: default # A module available by default
+```
+
+</TabItem>
+<TabItem value="example">
+
+```yaml
+format: 0.1.0
+env:
+  IPFS_PORT: $ENV_IPFS_PORT
+  DEV_SERVER_PORT: 4040
+  DEV_SERVER_ETH_TESTNET_PORT: 8545
+modules:
+  ipfs:
+    package: "@namestys/ipfs-infra"
+    version: "0.0.1"
+    registry: npm
+  dev-server:
+    path: ../local-packages/dev-server
+```
+</TabItem>
+</Tabs>
+
+## Infrastructure Modules
+
+An Infra manifest can declare any number of infrastructure modules. 
+Polywrap currently supports three types of infrastructure modules: 
+- A local module exists on your local filesystem.
+- A remote module is a package hosted by a package registry.
+- The default module is included with the CLI.
+
+### Local
+
+A local infrastructure module is a path from the Infra manifest to a local folder with a docker-compose file.
+
+```yaml title="Example: local module configuration"
+format: 0.1.0
+modules:
+  myLocal:
+    path: ../local-packages/myLocal
+```
+
+### Remote
+
+A remote infrastructure module is a package hosted at a package registry. 
+The package must contain a docker-compose file. 
+The path to the docker-compose file must be declared in the Infra manifest if the file is not located in the package root.
+
+Remote packages can be shared. 
+Users can add remote packages to their manifest to replicate the infrastructure modules defined by other users or projects.
+
+```yaml title="Example: remote module configuration"
+format: 0.1.0
+modules:
+  myIpfsNode:
+    package: "@namestys/ipfs-node"
+    version: "1.0.2"
+    registry: npm
+    dockerComposePath: ./config/docker-compose.yaml
+```
+
+### Default
+
+A default infrastructure module is included with the [`polywrap`](../../reference/cli/polywrap-cli) CLI. 
+It is declared in the Infra manifest as a module named *eth-ens-ipfs* and the value *default*. 
+If an Infra manifest is not found, the Polywrap CLI [`infra`](../../reference/cli/commands/deploy) command will use
+this module.
+
+The default infrastructure module defines a docker container with:
+- A test server at http://localhost:**4040**
+- A Ganache Ethereum test network at http://localhost:**8545**
+- An IPFS node at http://localhost:**5001**
+
+It also sets up ENS smart contracts at initialization, so you can build wrappers and deploy them to an ENS registry 
+on your locally hosted testnet. The Ethereum address of the ENS registry is 0xe78A0F7E598Cc8b0Bb87894B0F60dD2a88d6a8Ab.
+
+```yaml title="Example: local module configuration"
+format: 0.1.0
+modules:
+  eth-ens-ipfs: default
+```

--- a/src/docs/reference/clients/js/libraries/test-env-js.md
+++ b/src/docs/reference/clients/js/libraries/test-env-js.md
@@ -1,0 +1,127 @@
+---
+id: test-env-js
+title: '@polywrap/test-env-js'
+---
+
+The `@polywrap/test-env-js` package is a library of functions that facilitate end-to-end testing in JavaScript.
+The package is based on the default infrastructure module described in 
+[Configure Polywrap infrastructure pipeline](./../../..//quick-start/test-wasm-wrappers/infra-pipeline).
+
+## Constants
+
+### providers
+
+```typescript
+export const providers = {
+  ipfs: "http://localhost:5001",
+  ethereum: "http://localhost:8545",
+};
+```
+
+The `providers` object contains the URIs for the default infrastructure module's local Ethereum network provider and IPFS provider.
+
+### ensAddresses
+
+```typescript
+export const ensAddresses = {
+  ensAddress: "0xe78A0F7E598Cc8b0Bb87894B0F60dD2a88d6a8Ab", // ENS Registry
+  resolverAddress: "0x5b1869D9A4C187F2EAa108f3062412ecf0526b24", // ENS Resolver
+  registrarAddress: "0xD833215cBcc3f914bD1C9ece3EE7BF8B14f841bb", // ENS Registrar
+  reverseAddress: "0xe982E462b094850F12AF94d21D470e21bE9D0E9C", // ENS Reverse Lookup
+} as const;
+```
+
+The `ensAddresses` object contains the Ethereum addresses of the default infrastructure module's locally-deployed ENS smart contracts.
+
+## Methods
+
+### initTestEnvironment
+
+```typescript
+export const initTestEnvironment = async (cli?: string): Promise<void>
+```
+
+The `initTestEnvironment` function starts a local test environment using the default infrastructure module. 
+It optionally accepts a path to a [`polywrap`](./../../cli/polywrap-cli) CLI binary.
+
+### stopTestEnvironment
+
+```typescript
+export const stopTestEnvironment = async (cli?: string): Promise<void>
+```
+
+The `stopTestEnvironment` function tears down the local test environment (default infrastructure module) if one is running.
+It optionally accepts a path to a [`polywrap`](./../../cli/polywrap-cli) CLI binary.
+
+### buildWrapper
+
+```typescript
+export async function buildWrapper(wrapperAbsPath: string): Promise<void>
+```
+
+The `buildWrapper` function builds the wrapper located at the given path `wrapperAbsPath`.
+
+### buildAndDeployWrapper
+
+```typescript
+export async function buildAndDeployWrapper({
+  wrapperAbsPath,
+  ipfsProvider,
+  ethereumProvider,
+  ensName,
+}: {
+  wrapperAbsPath: string; // Absolute path of folder containing wrapper's Polywrap Manifest (polywrap.yaml)
+  ipfsProvider: string; // IPFS provider
+  ethereumProvider: string; // Ethereum provider
+  ensName?: string; // (Optional) ENS domain name
+}): Promise<{
+  ensDomain: string; // ENS domain for invoking wrapper
+  ipfsCid: string; // IPFS content hash for invoking wrapper
+}>
+```
+
+Like `buildWrapper`, the `buildAndDeployWrapper` function builds the wrapper located at the given path `wrapperAbsPath`.
+After building the wrapper, `buildAndDeployWrapper` deploys it to IPFS using the given provider `ipfsProvider`. 
+It next registers the ENS domain `ensName` and points the domain to the IPFS deployment using the Ethereum provider `ethereumProvider`. 
+If an ENS domain is not provided, a randomly selected human-readable ENS domain name is used. 
+The `buildAndDeployWrapper` function returns a Promise containing the ENS domain and IPFS content hash of the wrapper deployment,
+either of which can be used to invoke the wrapper.
+
+```typescript title="Example: buildAndDeployWrapper with default infrastructure module"
+import { buildAndDeployWrapper, providers } from "@polywrap/test-env-js";
+
+const api = await buildAndDeployWrapper({
+  wrapperAbsPath: "...",
+  ipfsProvider: providers.ipfs,
+  ethereumProvider: providers.ethereum,
+});
+const ensUri = `ens/testnet/${api.ensDomain}`;
+```
+
+### runCLI
+
+```typescript
+export const runCLI = async (options: {
+  args: string[]; // Command and arguments
+  cwd?: string; // (Optional) Current working directory
+  cli?: string; // (Optional) Path to CLI binary
+  env?: Record<string, string>; // (Optional) Environmental variables to set
+}): Promise<{
+  exitCode: number; // CLI exit code
+  stdout: string; // CLI standard output
+  stderr: string; // CLI standard error
+}>
+```
+
+The `runCLI` function can be used to run the [`polywrap`](./../../cli/polywrap-cli) CLI programmatically. 
+It requires an array of command line arguments `args`, which should include the CLI command to be run.
+An alternative current working directory `cwd` can be provided to change the context from which the CLI is invoked.
+It also optionally accepts a path to a [`polywrap`](./../../cli/polywrap-cli) CLI binary.
+The optional map of environmental variables `env` will be set before running the CLI.
+
+```typescript title="Example: runCLI calling the 'infra' command"
+const { exitCode, stderr, stdout } = await runCLI({
+  args: ["infra", "up", "--modules=eth-ens-ipfs", "--verbose"]
+});
+```
+


### PR DESCRIPTION
This PR:
 - Adds documentation for infrastructure pipeline and manifest
 - Adds reference documentation for @polywrap/test-env-js
 - Updates end-to-end test doc
 - Simplifies documentation on meta manifest and adding metadata
 - Hides uniswap v3 SDK to Wrapper case study