### PR TITLE
Added docs: declaring and implementing interfaces

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -81,8 +81,9 @@ module.exports = {
           type: 'category',
           label: 'Interfaces',
           items: [
+            'quick-start/interfaces/client-config-interfaces',
             'quick-start/interfaces/define-implement-interfaces',
-            'quick-start/interfaces/client-config-interfaces'
+            'quick-start/interfaces/interface-instances'
           ],
         },
         {

--- a/sidebars.js
+++ b/sidebars.js
@@ -79,6 +79,14 @@ module.exports = {
         },
         {
           type: 'category',
+          label: 'Interfaces',
+          items: [
+            'quick-start/interfaces/define-implement-interfaces',
+            'quick-start/interfaces/client-config-interfaces'
+          ],
+        },
+        {
+          type: 'category',
           label: 'Workflows',
           items: [
             'quick-start/workflows/running-workflows',

--- a/src/docs/quick-start/interfaces/client-config-interfaces.md
+++ b/src/docs/quick-start/interfaces/client-config-interfaces.md
@@ -1,0 +1,27 @@
+---
+id: client-config-interfaces
+title: Configure Interfaces in the Client
+---
+
+The [Polywrap Client](../../reference/clients/js/client-js) can be configured to use one or more implementations for
+an abstract interface wrapper.
+
+The `interfaces` property of the `ClientConfig` is declared as an array of `InterfaceImplementation`.
+Each `InterfaceImplementation` is assigned an interface wrapper URI and an array of URIs pointing to Wasm and plugin wrappers
+that implement the interface.
+
+For example, the URI Resolver interface is provided three implementation URIs in the 
+[Polywrap Client default configuration](https://github.com/polywrap/monorepo/blob/origin/packages/js/client/src/default-client-config.ts).
+
+```typescript
+interfaces: [
+  {
+    interface: coreInterfaceUris.uriResolver,
+    implementations: [
+      new Uri("wrap://ens/ipfs-resolver.polywrap.eth"),
+      new Uri("wrap://ens/ens-resolver.polywrap.eth"),
+      new Uri("wrap://ens/fs-resolver.polywrap.eth"),
+    ],
+  }
+]
+```

--- a/src/docs/quick-start/interfaces/client-config-interfaces.md
+++ b/src/docs/quick-start/interfaces/client-config-interfaces.md
@@ -1,6 +1,6 @@
 ---
 id: client-config-interfaces
-title: Configure Interfaces in the Client
+title: Configure interfaces in the client
 ---
 
 The [Polywrap Client](../../reference/clients/js/client-js) can be configured to use one or more implementations for

--- a/src/docs/quick-start/interfaces/define-implement-interfaces.md
+++ b/src/docs/quick-start/interfaces/define-implement-interfaces.md
@@ -1,6 +1,6 @@
 ---
 id: define-implement-interfaces
-title: Define and Implement Interfaces
+title: Define and implement interfaces
 ---
 
 import Tabs from '@theme/Tabs';
@@ -14,7 +14,7 @@ For example, the [URI Resolver](https://github.com/polywrap/monorepo/tree/origin
 interface is used to standardize the interface of URI resolvers. 
 It is implemented by multiple plugin wrappers to help the Polywrap client query different types of URIs.
 
-## Declaring an Interface Project
+## Declaring an interface project
 
 Interface projects are declared using a [Polywrap Manifest](./create-wasm-wrappers/polylwrap-manifest).
 To indicate that a project is an abstract interface, set the project language to `interface`.
@@ -29,7 +29,7 @@ language: interface
 schema: ./src/schema.graphql
 ```
 
-## Defining an Interface
+## Defining an interface
 
 Defining an interface is as simple as writing the [Wrapper Schema](./wrapper-schema). 
 Once the schema is complete, you are ready to deploy the interface wrapper.

--- a/src/docs/quick-start/interfaces/define-implement-interfaces.md
+++ b/src/docs/quick-start/interfaces/define-implement-interfaces.md
@@ -1,0 +1,84 @@
+---
+id: define-implement-interfaces
+title: Define and Implement Interfaces
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+A special type of Polywrap project can be used to define an abstract interface without providing a concrete implementation.
+Like other wrappers, the interface is defined using a [Wrapper Schema](./wrapper-schema).
+Once an interface is written and deployed, other projects can import and implement it.
+
+For example, the [URI Resolver](https://github.com/polywrap/monorepo/tree/origin/packages/interfaces/uri-resolver) 
+interface is used to standardize the interface of URI resolvers. 
+It is implemented by multiple plugin wrappers to help the Polywrap client query different types of URIs.
+
+## Declaring an Interface Project
+
+Interface projects are declared using a [Polywrap Manifest](./create-wasm-wrappers/polylwrap-manifest).
+To indicate that a project is an abstract interface, set the project language to `interface`.
+
+Interface projects do not have a module. Only a [schema](./wrapper-schema) path is declared.
+
+```yaml
+format: 0.1.0
+name: UriResolver
+deploy: ./polywrap.deploy.yaml
+language: interface
+schema: ./src/schema.graphql
+```
+
+## Defining an Interface
+
+Defining an interface is as simple as writing the [Wrapper Schema](./wrapper-schema). 
+Once the schema is complete, you are ready to deploy the interface wrapper.
+
+## Implementing an interface
+
+As described in [Wrapper Schema](../wrapper-schema#interfaces), 
+an interface can be imported and then implemented with the `implements` keyword. 
+When a module `implements` an interface module, it inherits all of its method declarations.
+
+The [ENS Resolver](https://github.com/polywrap/monorepo/tree/origin/packages/js/plugins/uri-resolvers/ens-resolver) plugin
+implements the [URI Resolver](https://github.com/polywrap/monorepo/tree/origin/packages/interfaces/uri-resolver) interface
+and inherits its methods.
+
+<Tabs
+defaultValue="ens"
+values={[
+{label: 'ENS Resolver Schema', value: 'ens'},
+{label: 'URI Resolver Schema', value: 'uri'},
+]}>
+<TabItem value="ens">
+
+```yaml
+#import { Module, MaybeUriOrManifest } into UriResolver from "ens/uri-resolver.core.polywrap.eth"
+#import { Module } into Ethereum from "ens/ethereum.polywrap.eth"
+
+type Module implements UriResolver_Module {}
+```
+
+</TabItem>
+<TabItem value="uri">
+
+```yaml
+type Module {
+  tryResolveUri(
+    authority: String!
+    path: String!
+  ): MaybeUriOrManifest
+
+  getFile(
+    path: String!
+  ): Bytes
+}
+
+type MaybeUriOrManifest {
+  uri: String
+  manifest: Bytes
+}
+```
+
+</TabItem>
+</Tabs>

--- a/src/docs/quick-start/interfaces/define-implement-interfaces.md
+++ b/src/docs/quick-start/interfaces/define-implement-interfaces.md
@@ -7,7 +7,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 A special type of Polywrap project can be used to define an abstract interface without providing a concrete implementation.
-Like other wrappers, the interface is defined using a [Wrapper Schema](./wrapper-schema).
+Like other wrappers, the interface is defined using a [Wrapper Schema](../wrapper-schema).
 Once an interface is written and deployed, other projects can import and implement it.
 
 For example, the [URI Resolver](https://github.com/polywrap/monorepo/tree/origin/packages/interfaces/uri-resolver) 
@@ -16,10 +16,10 @@ It is implemented by multiple plugin wrappers to help the Polywrap client query 
 
 ## Declaring an interface project
 
-Interface projects are declared using a [Polywrap Manifest](./create-wasm-wrappers/polylwrap-manifest).
+Interface projects are declared using a [Polywrap Manifest](../create-wasm-wrappers/polywrap-manifest).
 To indicate that a project is an abstract interface, set the project language to `interface`.
 
-Interface projects do not have a module. Only a [schema](./wrapper-schema) path is declared.
+Interface projects do not have a module. Only a [schema](../wrapper-schema) path is declared.
 
 ```yaml
 format: 0.1.0
@@ -31,7 +31,7 @@ schema: ./src/schema.graphql
 
 ## Defining an interface
 
-Defining an interface is as simple as writing the [Wrapper Schema](./wrapper-schema). 
+Defining an interface is as simple as writing the [Wrapper Schema](../wrapper-schema). 
 Once the schema is complete, you are ready to deploy the interface wrapper.
 
 ## Implementing an interface

--- a/src/docs/quick-start/interfaces/interface-instances.md
+++ b/src/docs/quick-start/interfaces/interface-instances.md
@@ -5,31 +5,52 @@ title: Interface instances
 
 Interface modules can be instantiated in a Wasm wrapper, agnostic to any concrete implementation.
 
-## Declaring getImplementations
+## Instantiating an interface
 
-In addition to importing the interface module, you must declare that an interface will be instantiated with the 
-`use { getImplementations }` keywords.
+After an interface is imported in your [Wrapper Schema](../wrapper-schema), you can update the generated classes with the
+Polywrap CLI's [`codegen`](../../reference/cli/commands/codegen) command.
+You will then be able to import the interface module in your wrapper.
+
+To instantiate an interface module, you must provide a URI that resolves to a wrapper that implements the interface.
+
+```typescript
+import { MyInterface_Module, Args_foo } from "./wrap";
+
+export function foo(args: Args_foo): boolean {
+  const instance = new MyInterface_Module("wrap://...");
+  ...
+}
+```
+
+## Getting Interface Implementations
+
+To instantiate an interface agnostic to the implementation, 
+you can use `getImplementations` to obtain a list of interface implementations registered in the Polywrap Client.
+
+### Declaring getImplementations
+
+In addition to importing the interface module in the [Wrapper Schema](../wrapper-schema), 
+you must declare that `getImplementations` will be used for the interface with the `use { getImplementations }` keywords.
 
 ```graphql
 #import { Module } into MyInterface from "wrap://ens/interface.eth"
 #use { getImplementations } for MyInterface
 ```
 
-## Instantiating an interface
+### Using getImplementations
 
-After an interface is imported and the use of `getImplementations` is declared, 
-you can update the generated classes with the Polywrap CLI's [`codegen`](../../reference/cli/commands/codegen) command.
-You will then be able to import the interface module in your wrapper.
-
-To instantiate the interface module, you must provide a URI that resolves to a wrapper that implements the interface.
-To use the interface with an agnostic implementation, you can accept the implementation URI as a function argument
-or environmental variable.
+Now you can import the interface namespace and call its `getImplementations` method. 
+The `getImplementations` method returns an array of URI strings that can be used to instantiate the interface module.
 
 ```typescript
-import { MyInterface_Module, Args_foo } from "./wrap";
+import { MyInterface, MyInterface_Module, Args_foo } from "./wrap";
 
 export function foo(args: Args_foo): boolean {
-  const instance = new MyInterface_Module(args.implementationUri);
-  ...
+  const impls = MyInterface.getImplementations();
+  if (impls.length < 1) {
+    throw new Error("...")
+  }
+  const instance = new MyInterface_Module(impls[0]);
+...
 }
 ```

--- a/src/docs/quick-start/interfaces/interface-instances.md
+++ b/src/docs/quick-start/interfaces/interface-instances.md
@@ -1,0 +1,35 @@
+---
+id: interface-instances
+title: Interface instances
+---
+
+Interface modules can be instantiated in a Wasm wrapper, agnostic to any concrete implementation.
+
+## Declaring getImplementations
+
+In addition to importing the interface module, you must declare that an interface will be instantiated with the 
+`use { getImplementations }` keywords.
+
+```graphql
+#import { Module } into MyInterface from "wrap://ens/interface.eth"
+#use { getImplementations } for MyInterface
+```
+
+## Instantiating an interface
+
+After an interface is imported and the use of `getImplementations` is declared, 
+you can update the generated classes with the Polywrap CLI's [`codegen`](../../reference/cli/commands/codegen) command.
+You will then be able to import the interface module in your wrapper.
+
+To instantiate the interface module, you must provide a URI that resolves to a wrapper that implements the interface.
+To use the interface with an agnostic implementation, you can accept the implementation URI as a function argument
+or environmental variable.
+
+```typescript
+import { MyInterface_Module, Args_foo } from "./wrap";
+
+export function foo(args: Args_foo): boolean {
+  const instance = new MyInterface_Module(args.implementationUri);
+  ...
+}
+```


### PR DESCRIPTION
Added documentation on:
 - declaring and implementing interfaces
 - configuring interfaces in the client config
 - instantiating interfaces in wrappers, and the `#use` keyword

Closes https://github.com/polywrap/documentation/issues/43