### PR TITLE
documentation for client configuration

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -24,6 +24,7 @@ module.exports = {
           items: [
             'quick-start/create-js-app/install-client',
             'quick-start/create-js-app/create-client-instance',
+            'quick-start/create-js-app/configure-client',
             'quick-start/create-js-app/react-integration',
             'quick-start/create-js-app/get-wrapper-metadata',
           ],
@@ -123,6 +124,7 @@ module.exports = {
               label: 'JavaScript',
               items: [
                 'reference/clients/js/client-js',
+                'reference/clients/js/client-config',
                 {
                   type: 'category',
                   label: 'Libraries',

--- a/src/docs/quick-start/create-js-app/configure-client.md
+++ b/src/docs/quick-start/create-js-app/configure-client.md
@@ -1,0 +1,109 @@
+---
+id: 'configure-client'
+title: 'Configure the Polywrap Client'
+---
+
+The Polywrap Client accepts a [`ClientConfig`](../../reference/clients/js/client-config) argument at construction. 
+
+While the [default Client Config](https://github.com/polywrap/monorepo/blob/origin/packages/js/client/src/default-client-config.ts)
+is sufficient for some use cases, you will likely want to customize it.
+The config you provide to the client will modify and add to the default configuration.
+
+## The `ClientConfig` object
+
+The [`PolywrapClient`](../../reference/clients/js/client-js) can be configured to redirect URIs, use different plugins, 
+register interface implementations, set environmental variables, and customize URI resolution.
+
+```typescript
+interface ClientConfig {
+  redirects: UriRedirect[]; // redirect queries from one uri to another
+  plugins: PluginRegistration[]; // declare and configure plugins
+  interfaces: InterfaceImplementations[]; // declare interface implementations
+  envs: Env[]; // set environmental variables
+  uriResolvers: UriResolver[]; // resolve custom URIs
+}
+```
+
+## Redirects
+
+[URI Redirects](../../concepts/understanding-uri-redirects) can be used to redirect queries from one URI to another. 
+This redirection occurs in all queries to the URI, even in cases where one wrapper calls another during its execution.
+
+```typescript
+const clientConfig: Partial<ClientConfig> = {
+  redirects: [
+    {
+      from: "wrap://ens/from.eth", // uri to redirect from
+      to: "wrap://ens/to.eth", // uri to redirct to
+    }
+  ],
+};
+```
+
+
+## Plugins
+
+To use a [plugin wrapper](../../concepts/understanding-plugins), it has to be registered in the [`ClientConfig`](../../reference/clients/js/client-config).
+Each item in the array of plugins contains the URI at which the plugin will be invoked and a `PluginPackage`.
+A `PluginPackage` is a factory function the [`PolywrapClient`](../../reference/clients/js/client-js) uses to create new
+instances of the plugin. 
+Each plugin can have its own configuration.
+
+```typescript
+const clientConfig: Partial<ClientConfig> = {
+  plugins: [
+    {
+      uri: "wrap://ens/ethereum.polywrap.eth",
+      plugin: ethereumPlugin({
+        networks: {
+          testnet: {
+            provider: "http://localhost:8545"
+          },
+        },
+        defaultNetwork: "testnet",
+      }),
+    },
+  ],
+};
+```
+
+## Interfaces
+
+Users can declare custom implementations for an interface by providing the interface URI and one or more URIs that resolve to implementations.
+
+```typescript
+const clientConfig: Partial<ClientConfig> = {
+  interfaces: [
+    {
+      interface: "wrap://ens/logger.core.polywrap.eth",
+      implementations: ["wrap://ens/js-logger.polywrap.eth"],
+    },
+  ],
+};
+```
+
+
+## Envs
+
+Users can provide wrapper-specific environmental variables by providing the wrapper URI and an object with strings as keys.
+
+```typescript
+const clientConfig: Partial<ClientConfig> = {
+  envs: [
+    {
+      uri: "wrap://ens/wrapper.eth",
+      env: {
+        connection: {
+          networkNameOrChainId: "polygon",
+        },
+      },
+    },
+  ],
+};
+```
+
+## Uri Resolvers
+
+By default, the Client can resolve ENS, IPFS, and filesystem URIs.
+It is possible to use custom URI Resolvers as well.
+Documentation on how to do so is coming soon!

--- a/src/docs/quick-start/workflows/running-workflows.md
+++ b/src/docs/quick-start/workflows/running-workflows.md
@@ -60,7 +60,7 @@ configuration file.
 The configuration file can be a JavaScript or TypeScript module.
 It must implement and export a function named `getClientConfig`. 
 
-The `getClientConfig` function accepts the default `PolywrapClientConfig` as an argument and returns the custom Polywrap 
+The `getClientConfig` function accepts the default `ClientConfig` as an argument and returns the custom Polywrap 
 client configuration. 
 It must be implemented with the following signature:
 

--- a/src/docs/quick-start/workflows/running-workflows.md
+++ b/src/docs/quick-start/workflows/running-workflows.md
@@ -60,7 +60,7 @@ configuration file.
 The configuration file can be a JavaScript or TypeScript module.
 It must implement and export a function named `getClientConfig`. 
 
-The `getClientConfig` function accepts the default `ClientConfig` as an argument and returns the custom Polywrap 
+The `getClientConfig` function accepts the default [`ClientConfig`](../create-js-app/configure-client) as an argument and returns the custom Polywrap 
 client configuration. 
 It must be implemented with the following signature:
 

--- a/src/docs/reference/clients/js/client-config.md
+++ b/src/docs/reference/clients/js/client-config.md
@@ -1,0 +1,107 @@
+---
+id: 'client-config'
+title: Client Config
+---
+
+The Polywrap Client accepts a `ClientConfig` argument at construction.
+The default configuration can be modified to redirect URIs, use different plugins, register interface implementations,
+set environmental variables, and customize URI resolution.
+
+```typescript
+interface ClientConfig<TUri extends Uri | string = string> {
+  redirects: UriRedirect<TUri>[]; // redirect queries from one uri to another
+  plugins: PluginRegistration<TUri>[]; // declare and configure plugins
+  interfaces: InterfaceImplementations<TUri>[]; // declare interface implementations
+  envs: Env<TUri>[]; // set environmental variables
+  uriResolvers: UriResolver[]; // resolve custom URIs
+}
+```
+
+## Redirects
+
+The `redirects` property can be used to redirect queries from one URI to another.
+This redirection occurs in all queries to the URI, even in cases where one wrapper calls another during its execution.
+
+```typescript
+interface UriRedirect<TUri = string> {
+  from: TUri; // uri to redirect from
+  to: TUri; // uri to redirct to
+}
+```
+
+## Plugins
+
+Polywrap plugin wrappers are written in a Client’s native language.
+They offer a user experience similar to that of wrappers, but with different benefits.
+
+Plugins are declared and constructed in the Client config by providing an array of `PluginRegistration`.
+Each `PluginRegistration` contains the URI at which the plugin will be queried and a `PluginPackage`.
+A `PluginPackage` is a factory function the [`PolywrapClient`](../../reference/clients/js/client-js) uses to create new
+instances of the plugin.
+Each plugin can have its own configuration.
+
+```typescript
+interface PluginRegistration<TUri = string> {
+  uri: TUri; // URI that will be redirected to plugin
+  plugin: PluginPackage<unknown>; // plugin factory
+}
+```
+
+## Interfaces
+
+Users can declare custom implementations for an interface by providing the interface URI and one or more URIs that resolve to implementations.
+
+```typescript
+interface InterfaceImplementations<TUri = string> {
+  interface: TUri; // interface URI
+  implementations: TUri[]; // URIs of wrappers implementing interface
+}
+```
+
+## Envs
+
+Because wrapper calls are sandboxed and stateless, they cannot access the global state that persists outside the call.
+Users can instead provide wrapper-specific environmental variables in the Client configuration.
+Wrapper developers are expected to inform users which environmental variables should be set for their API.
+
+```typescript
+interface Env<TUri = string> {
+  uri: TUri; // URI of wrapper
+  env: Record<string, unknown>; // environmental variables used by the module
+}
+```
+
+## Uri Resolvers
+
+Users can extend the Client's URI resolution capabilities by providing new implementations of `UriResolver`.
+A `UriResolver` takes a URI as input and resolves it to a wrapper or plugin.
+
+By default, the Client includes an ExtendableUriResolver that can accept ENS, IPFS, and filesystem URIs as input and fetch wrappers from those sources.
+It is "extendable" in the sense that it works with any plugin or wrapper that implements the `UriResolverInterface`.
+The Client's default resolvers can also resolve URI's that point to redirects, plugins, and cached wrappers.
+
+```typescript
+abstract class UriResolver {
+  public abstract get name(): string;
+
+  public abstract resolveUri(
+    uri: Uri,
+    client: Client,
+    cache: ApiCache,
+    resolutionPath: UriResolutionStack
+  ): Promise<UriResolutionResult>;
+}
+```
+
+## Default Configuration
+
+The current default `ClientConfig` for the JavaScript implementation of the `PolywrapClient` can be viewed on [Github][default config].
+When a user provides a `ClientConfig` to the Client, the default configuration is still applied.
+The default configuration is modified by the user's configuration.
+
+## Sanitization
+
+The Client's configuration is *sanitized* when the Client is constructed.
+During the sanitization process, URI strings are validated and transformed into instances of the `Uri` class.
+
+[default config]: https://github.com/polywrap/monorepo/blob/origin/packages/js/client/src/default-client-config.ts

--- a/src/docs/reference/clients/js/client-config.md
+++ b/src/docs/reference/clients/js/client-config.md
@@ -36,7 +36,7 @@ They offer a user experience similar to that of wrappers, but with different ben
 
 Plugins are declared and constructed in the Client config by providing an array of `PluginRegistration`.
 Each `PluginRegistration` contains the URI at which the plugin will be queried and a `PluginPackage`.
-A `PluginPackage` is a factory function the [`PolywrapClient`](../../reference/clients/js/client-js) uses to create new
+A `PluginPackage` is a factory function the [`PolywrapClient`](./client-js) uses to create new
 instances of the plugin.
 Each plugin can have its own configuration.
 


### PR DESCRIPTION
This PR adds:
- a page in quick-start about configuring the client
- a more detailed page about `ClientConfig` in the reference docs

Closes https://github.com/polywrap/documentation/issues/44