### PR TITLE
add package to auto-ingress reference readmes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ yarn-error.log*
 build-error.log
 snippets.txt
 snippets.json
+
+# Cloned repos
+/clones

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "build:docs": "yarn doc-snippets combine ./snippets ./src/docs ./docs --ignore node_modules .polywrap/",
     "rebuild:docs": "npx rimraf ./docs && yarn build:docs",
     "build:snippets": "ts-node ./scripts/build-snippets.ts",
-    "rtd": "rtd run --root ../toolchain --outDir ./reference --exclude 'node_modules|src|build|workflows|scripts|.polywrap|test-cases'"
+    "clone:repos": "ts-node ./scripts/clone-repos.ts",
+    "clone:readmes": "ts-node ./scripts/clone-readmes.ts"
   },
   "resolutions": {
     "terser": "4.8.0"
@@ -51,8 +52,7 @@
     "onchange": "7.1.0",
     "rimraf": "3.0.2",
     "ts-node": "10.7.0",
-    "typescript": "4.6.4",
-    "readme-to-doc": "^0.0.2"
+    "typescript": "4.6.4"
   },
   "browserslist": {
     "production": [

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "build:app": "docusaurus build",
     "build:docs": "yarn doc-snippets combine ./snippets ./src/docs ./docs --ignore node_modules .polywrap/",
     "rebuild:docs": "npx rimraf ./docs && yarn build:docs",
-    "build:snippets": "ts-node ./scripts/build-snippets.ts"
+    "build:snippets": "ts-node ./scripts/build-snippets.ts",
+    "rtd": "rtd run --root ../toolchain --outDir ./reference --exclude 'node_modules|src|build|workflows|scripts|.polywrap|test-cases'"
   },
   "resolutions": {
     "terser": "4.8.0"
@@ -50,7 +51,8 @@
     "onchange": "7.1.0",
     "rimraf": "3.0.2",
     "ts-node": "10.7.0",
-    "typescript": "4.6.4"
+    "typescript": "4.6.4",
+    "readme-to-doc": "^0.0.2"
   },
   "browserslist": {
     "production": [

--- a/scripts/clone-readmes.ts
+++ b/scripts/clone-readmes.ts
@@ -1,0 +1,54 @@
+import path from 'path';
+import fs from 'fs';
+
+const clonesDir: string = path.resolve(path.join(__dirname, "../clones"));
+const referenceDir: string = path.resolve(path.join(__dirname, "../src/docs/reference"));
+
+// paths are relative to clone and reference doc dirs
+const repoToPaths: Record<string, string> = {
+  "./polywrap/toolchain/packages/js/client/README.md": "./clients/js/client-js.md",
+  "./polywrap/toolchain/packages/cli/README.md": "./cli/polywrap-cli.md"
+}
+
+async function main() {
+  for (const [relReadmePath, relDocPath] of Object.entries(repoToPaths)) {
+    const readmePath = path.resolve(path.join(clonesDir, relReadmePath));
+    const docPath = path.resolve(path.join(referenceDir, relDocPath));
+
+    if (!fs.existsSync(readmePath)) {
+      throw Error(`Path does not exist: ${readmePath}`);
+    }
+
+    const readme = fs.readFileSync(readmePath, 'utf-8');
+    writeReadmeAsDoc(docPath, readme);
+  }
+
+  console.log("Successfully copied readmes to reference dir");
+  process.exit(0);
+}
+
+function writeReadmeAsDoc(docPath: string, readme: string): void {
+  const dir = path.dirname(docPath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+
+  const id = path.basename(docPath, ".md");
+  const title = id.replace(/-/g, " ");
+
+  const doc = `---
+id: ${id}
+title: ${title}
+---
+
+` + readme;
+
+  fs.writeFileSync(docPath, doc);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/scripts/clone-readmes.ts
+++ b/scripts/clone-readmes.ts
@@ -5,13 +5,13 @@ const clonesDir: string = path.resolve(path.join(__dirname, "../clones"));
 const referenceDir: string = path.resolve(path.join(__dirname, "../src/docs/reference"));
 
 // paths are relative to clone and reference doc dirs
-const repoToPaths: Record<string, string> = {
+const readmeToDocPaths: Record<string, string> = {
   "./polywrap/toolchain/packages/js/client/README.md": "./clients/js/client-js.md",
   "./polywrap/toolchain/packages/cli/README.md": "./cli/polywrap-cli.md"
 }
 
 async function main() {
-  for (const [relReadmePath, relDocPath] of Object.entries(repoToPaths)) {
+  for (const [relReadmePath, relDocPath] of Object.entries(readmeToDocPaths)) {
     const readmePath = path.resolve(path.join(clonesDir, relReadmePath));
     const docPath = path.resolve(path.join(referenceDir, relDocPath));
 

--- a/scripts/clone-repos.ts
+++ b/scripts/clone-repos.ts
@@ -1,0 +1,108 @@
+import { exec, ExecException } from 'child_process';
+import path from 'path';
+import fs from 'fs';
+
+type Repo = {
+  org?: string; // defaults to "polywrap"
+  name: string;
+  branch: string;
+}
+
+const repos: Repo[] = [
+  {
+    name: "toolchain",
+    branch: "origin"
+  }
+]
+
+const clonesRoot = path.resolve(path.join(__dirname, "..", "clones"));
+
+async function main() {
+  if (!fs.existsSync(clonesRoot)) {
+    fs.mkdirSync(clonesRoot);
+  }
+
+  const promises = repos.map(cloneRepo);
+  const results = await Promise.allSettled(promises);
+
+  let err = false;
+  for (const result of results) {
+    if (result.status === "rejected") {
+      err = true;
+      console.log(result.reason);
+    }
+  }
+
+  if (!err) {
+    console.log("Successfully cloned repos");
+  }
+}
+
+// clone a repo, keeping only the latest commit on a single specific branch
+// also removes the .git folder
+async function cloneRepo(repo: Repo): Promise<{ stdout?: string; stderr?: string }> {
+  const { name, branch } = repo;
+  const org = repo.org ?? "polywrap";
+  
+  // make sure org dir exists
+  const orgRoot = path.join(clonesRoot, org);
+  if (!fs.existsSync(orgRoot)) {
+    fs.mkdirSync(orgRoot);
+  }
+
+  // clone repo
+  const uri = `https://github.com/${org}/${name}.git`;
+  const result = await runCommand(
+    "git clone",
+    ["-b", branch, "--depth", "1", "--single-branch", uri],
+    undefined,
+    orgRoot
+  );
+
+  // remove .git data
+  const dotGitPath = path.join(orgRoot, name, "/.git/");
+  await fs.promises.rm(dotGitPath, { recursive: true, force: true });
+
+  return result;
+}
+
+async function runCommand(
+  command: string,
+  args: string[],
+  env: Record<string, string> | undefined = undefined,
+  cwd: string | undefined = undefined,
+): Promise<{ stdout: string; stderr: string }> {
+
+  return new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
+    const callback = (
+      err: ExecException | null,
+      stdout: string,
+      stderr: string
+    ) => {
+      if (err) {
+        reject({ stdout, stderr });
+      } else {
+        resolve({ stdout, stderr });
+      }
+    };
+
+    exec(
+      [command, ...args].join(" "),
+      {
+        cwd: cwd ?? __dirname,
+        env: {
+          ...process.env,
+          ...env,
+        },
+      },
+      callback
+    );
+  });
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/src/docs/reference/cli/polywrap-cli.md
+++ b/src/docs/reference/cli/polywrap-cli.md
@@ -1,9 +1,10 @@
 ---
 id: polywrap-cli
 title: 'Polywrap CLI'
+sidebar_position: 0
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+
+# The Polywrap CLI (`polywrap`)
 
 <a href="https://www.npmjs.com/package/polywrap" target="_blank" rel="noopener noreferrer">
 <img src="https://img.shields.io/npm/v/polywrap.svg" alt="npm"/>
@@ -12,55 +13,582 @@ import TabItem from '@theme/TabItem';
 <br/>
 <br/>
 
-Command line interface for building with Polywrap.
+A command-line interface for building and deploying Polywrap projects.
+
 
 ## Prerequisites
 
-[Docker](https://www.docker.com/) is required to perform some tasks, including to [`build`](./commands/build) Wasm wrappers.
+### Docker
+
+[Docker](https://www.docker.com/) is required to perform some tasks, including to `build` Wasm wrappers.
 Linux users will also need to install [Docker Compose](https://docs.docker.com/compose/install/).
 Docker is free for personal use. Once Docker is installed and enabled, you're ready to go!
 
+### Cue
+
+The `polywrap run` command can validate runs by examining `stdout` output using **Cue**. If you need to run workflow validations, you will have to install Cue.
+
+You can install Cue by following the instructions found [here](https://cuelang.org/docs/install/).
+
 ## Installation
 
-<Tabs
-defaultValue="npm"
-values={[
-{label: 'npm', value: 'npm'},
-{label: 'yarn', value: 'yarn'},
-]}>
-  <TabItem value="npm">
-
-  ```bash
-  npm install polywrap
-  ```
-  </TabItem>
-  <TabItem value="yarn">
-
-  ```bash
-  yarn add polywrap
-  ```
-  </TabItem>
-</Tabs>
-
-:::tip
-Node v16 and above is recommended.
-:::
-
-## Usage
-
-To list available commands, run the `help` command:
+Within a single project:
 
 ```bash
+npm install --save-dev polywrap
+```
+
+Globally:
+
+```bash
+npm install -g polywrap
+```
+
+Alternatively, `polywrap` can be run without installation:
+
+```bash
+npx polywrap
+```
+
+## Commands
+
+### `help` command and `--help` option
+
+To list available commands, use the `help` command or the `-h, --help` option:
+
+```bash
+polywrap help
 polywrap --help
 ```
 
-The following menu will appear in your terminal window:
+Alternatively, you can use the `-h, --help` option within any command to get a full list of available subcommands, arguments and options.
 
-```sh
-$snippet: cli-command-help-
+```bash
+polywrap create --help
+polywrap codegen --help
 ```
 
-To learn about each command, simply add `--help` after the command name to be given a full description of the options available:
+### `build | b`
+
+Build Wasm and Interface Polywrap projects.
+This outputs the project's ABI schema (Wasm and Interface) and binary package (Wasm) into the `./build` directory.
+
+#### Options
+- `-m, --manifest-file <path>`
+  Specify your project's manifest file.
+  By default, `build` searches for `polywrap.yaml`.
+
+- `-o, --output-dir <path>`
+  Specify an alternative directory for build output.
+  The default codegen output directory is `./build`.
+
+- `-c, --client-config <config-path>`
+  Use a custom Polywrap Client configuration.
+
+- `--wrapper-envs <envs-path>`
+  Configure wrapper environment values using the provided file.
+
+- `-n, --no-codegen`
+  Don't perform codegen before building.
+  By default, `build` performs a `codegen` step before building your Project. This option skips this step. This is especially useful when you are testing manual changes to your types/bindings.
+
+- `-s, --strategy <strategy>`
+  Specify which build strategy to use. By default, the `vm` build strategy is used.
+  Available strategies:
+  - `vm`: Uses Docker only for the source building part of the build process. At build time, it pulls a pre-built image with all necessary system dependencies, env vars and runtime; and it instantiates a Docker container with it. The Docker container instantiates bind-mounts (volumes) to copy the sources and dependencies from the host, build the sources inside the container, and copy the build artifacts back to the host machine. This approach ensures that the sources will be built in a reproducible environment but it doesn't use Docker for anything else and no image is built at runtime.
+  - `image`: Implies building a Docker image at runtime, where dependencies are installed and sources are copied and built as Dockerfile instructions. On subsequent builds, Docker tries to reuse cached image layers and rebuild accordingly. This approach is notably slow but the complete process happens in Docker, and can be reproduced, examined and audited layer by layer (from dependency installation to build artifacts output).
+  - `local` - Does not use Docker at all. It simply executes a .sh file that contains the necessary instructions to install dependencies and build sources. While this is the fastest way of building, it requires you, the user, to have all prerequisite system dependencies installed. In addition, given that sources are built on the host machine and not a reproducible docker environment, reproducibility isn't guaranteed.
+
+- `-w, --watch`
+  Watch the Project's files and automatically rebuild when a file is changed.
+
+### `codegen | g`
+
+Generate code bindings for Polywrap projects.
+
+This command generates types and bindings for your project based on your project's schema (found in `schema.graphql`).
+
+#### Options
+- `-m, --manifest-file <path>`
+  Specify your project's manifest file.
+  By default, `docgen` searches for `polywrap.yaml`.
+  
+- `-g, --codegen-dir <path>`
+  Specify an alternative directory for codegen output.
+  The default codegen output directory is `./wrap`.
+  
+- `-p, --publish-dir <path>`
+  Output path for the built schema and manifest (default: `./build`)
+  This only applies when running `codegen` for Plugin Projects.
+
+- `-s, --script <path>`
+  Path to a custom generation script (JavaScript | TypeScript).
+  This script is run in place of the standard codegen script if provided.
+
+- `-c, --client-config <config-path>`
+  Use a custom Polywrap Client configuration.
+
+- `--wrapper-envs <envs-path>`
+  Configure wrapper environment values using the provided file.
+
+#### Special note
+
+When running `codegen` for Plugin Projects, the Polywrap CLI will also output an ABI schema for your plugin into the `./build` directory. You can override this output directory by specifying `-p, --publish-dir <path>`.
+
+### `create | c`
+
+Create a Polywrap project.
+
+This command sets up a basic Polywrap-enabled project based on a pre-defined template.
+
+#### Subcommands
+
+`polywrap create wasm <language> <name>`
+
+Set up a Polywrap WASM Wrapper or Interface project.
+
+`polywrap create app <language> <name>`
+
+Set up a NodeJS or React application which uses the Polywrap Client to invoke wrappers.
+
+`polywrap create plugin <language> <name>`
+
+Set up a Polywrap Plugin project used to provide the Polywrap Cient with additional functionality.
+
+#### Arguments
+
+All subcommands share the following arguments:
+
+- `language` (required)
+  The type/language of the created project
+
+- `name` (required)
+  The project name.
+
+#### Options
+
+All subcommands share the following options:
+
+- `-o, --output-dir <path>`
+  Specifies a custom output directory for the created project.
+
+#### Sample usage
+
 ```bash
-polywrap build --help
+# Create a wrapper project using assemblyscript called "my-wrapper"
+polywrap create wasm assemblyscript my-wrapper
+
+# Create an interface project using assemblyscript called "my-project"
+polywrap create wasm interface my-interface
+
+# Create a React app project using Typescript called "my-react-app"
+polywrap create app typescript-react my-react-app
+
+# Create a Plugin wrapper project using Typescript called "my-plugin"
+polywrap create plugin typescript my-plugin
+```
+
+### `deploy | d`
+
+Deploy Polywrap projects.
+
+```bash
+polywrap deploy
+```
+
+`deploy` reads the Deploy manifest (`polywrap.deploy.yaml` by default) and executes the jobs and steps listed inside.
+
+For more information on the Deploy command and the Deploy manifest, see [Configure Polywrap deployment pipeline](https://docs.polywrap.io/quick-start/build-and-deploy-wasm-wrappers/deploy-pipeline).
+
+#### Options
+- `-m, --manifest-file <path>`
+  Specify your project's manifest file.
+  By default, `deploy` searches for `polywrap.yaml`.
+
+- `-o, --output-file <path>`
+  Output file path for the deploy result
+
+### `infra | i`
+
+Modular Infrastructure-As-Code Orchestrator
+
+```bash
+polywrap infra <action> [options]
+```
+
+The `infra` command is used to set up infrastructure to test and deploy your wrappers locally.
+
+For more information on the `infra` command and how to create your own Infra modules, see [Configure Polywrap infrastructure pipeline](https://docs.polywrap.io/quick-start/test-wasm-wrappers/infra-pipeline)
+
+#### Arguments
+- `action` (required)
+  Infra allows you to execute the following actions:
+  - `up`
+    Start Polywrap infrastructure
+  - `down`
+    Stop Polywrap infrastructure
+  - `config`
+    Validate and display Polywrap infrastructure's bundled docker-compose manifest
+  - `vars`
+    Show Polywrap infrastructure's required .env variables
+
+#### Options
+- `-m, --manifest-file <path>`
+  Specify the `infra` extension manifest file.
+  By default, `infra` searches for `polywrap.infra.yaml`.
+
+- `-o, --modules <module, module>`
+  Use only specified modules
+
+#### Defaults
+
+Polywrap comes with a default `eth-ens-ipfs` module which can be used to test your wrappers locally:
+
+```
+polywrap infra up --modules=eth-ens-ipfs
+```
+
+The default infrastructure module defines a docker container with:
+
+- A test server at http://localhost:4040
+- A Ganache Ethereum test network at http://localhost:8545
+- An IPFS node at http://localhost:5001
+
+It also sets up ENS smart contracts at initialization, so you can build wrappers and deploy them to an ENS registry on your locally hosted testnet.
+
+Addresses for the components of ENS:
+- Registry: `0xe78A0F7E598Cc8b0Bb87894B0F60dD2a88d6a8Ab`
+- Resolver: `0x5b1869D9A4C187F2EAa108f3062412ecf0526b24`
+- Registrar: `0xD833215cBcc3f914bD1C9ece3EE7BF8B14f841bb`
+- Reverse Registrar: `0xe982E462b094850F12AF94d21D470e21bE9D0E9C`
+
+### `test | t`
+
+Run Test manifests. 
+
+The `test` command executes a series of Wrapper invocations called **steps** organized into **jobs**.
+All steps within a job are run in series, while jobs are run in parallel.
+
+```bash
+polywrap test [options]
+```
+
+#### Options
+- `-m, --manifest-file <path>`
+  Specify the Workflow extension manifest file.
+  By default, `run` searches for `polywrap.test.yaml`.
+
+- `-c, --client-config <config-path>`
+  Use a custom Polywrap Client configuration.
+
+- `--wrapper-envs <envs-path>`
+  Configure wrapper environment values using the provided file.
+
+- `-o, --output-file <output-file-path>`
+  Specify the output file path for the workflow result
+
+- `-j, --jobs <jobs...>`
+  Specify ids of jobs that you want to run
+
+#### The Test manifest (`polywrap.test.yaml`)
+Basic structure:
+
+```yaml
+# The basic structure of a test file 
+name: my-test-name #the name of the test
+format: 0.1.0
+validation: "path/to/validator.cue" #(optional) path to a validator file (cuelang)
+jobs:
+  first:
+    steps: #each step is a wrapper invocation that consists of a URI, the invoked method and its arguments
+    - uri: ens/example.eth
+      method: helloWorld
+      args:
+        arg1: "test"
+        ...
+    - ...
+    jobs: #after all job steps are executed, additional jobs can be run in parallel
+      ...
+  second:
+    ...
+```
+
+`jobs` is a map of `<string, Job>`, the key being each Job's name.
+
+```yaml
+jobs:
+  helloWorld:
+    ...
+  helloPolywrap:
+    ...
+```
+
+Each Job consists of two properties:
+  - a `steps` collection
+    - This is a wrapper invocation, consisting of:
+      - `uri` - the WRAP URI of the wrapper
+      - `method` - the name of the invoked wrapper method
+      - `args` (optional) - a map of the invoked method's arguments
+      - `config` (optional) - a map of client config properties to be added/overridden
+  - an inner `jobs` map, making the structure of `Job` recursive.
+
+```yaml
+jobs:
+  helloWorld:
+    steps:
+    - uri: ens/helloworld.polywrap.eth #ENS URI
+      method: helloWorld
+      args:
+        name: test
+    - uri: fs/./hello-polywrap/build #Filesystem URI
+      method: helloPolywrap
+    jobs:
+      innerJob1:
+      ...
+      innerJob2:
+      ...
+  helloPolywrap:
+    steps:
+    ...
+    jobs:
+    ...
+```
+
+When running a Test manifest, all top-level Jobs are run in parallel. Within those Jobs, each step is run in series. After all steps for a Job have been run, the inner `jobs` are run in parallel, with their `steps` run in series, and so on.
+
+You can reference the result (`data`/`error`) of any step by using the `$` symbol:
+
+```yaml
+jobs:
+  helloWorld:
+    steps:
+    - uri: ens/helloworld.polywrap.eth #ENS URI
+      method: helloWorld
+      args:
+        name: test
+    - uri: fs/./hello-polywrap/build #Filesystem URI
+      method: helloPolywrap
+    jobs:
+      innerJob1:
+        steps:
+        - uri: ens/helloworld.polywrap.eth
+          method: helloWorld
+          args:
+            name: "$helloWorld.1.data" #Reference to `helloWorld`'s 2nd step return value
+        jobs:
+          innerJob11:
+            steps:
+            - uri: ens/helloworld.polywrap.eth
+              method: helloWorld
+              args:
+                name: "$helloWorld.innerJob1.0.error" #Reference to helloWorld's innerJob1 1st step error
+```
+
+#### Test validation
+
+By specifying a `validation` file within your Test manifest, the result of the run will be validated using `cue`.
+
+Example of a validation file:
+
+```cuelang
+helloWorld: {
+  $0: {
+    data: "Hello test!",
+    error?: _|_, // Never fails
+  }
+  $1: {
+    data: "Hello Polywrap!",
+    error?: _|_, // Never fails
+  }
+  innerJob1: {
+    $0: {
+      data: "Hello Hello test!!",
+      error?: _|_,
+    }
+  }
+}
+```
+
+### `docgen | o`
+
+Generate wrapper documentation for your project.
+
+```bash
+polywrap docgen <action>
+```
+
+#### Arguments
+
+- `action` (required)
+  Specifies the kind of documentation generated.
+  Values:
+  - `schema`
+    Generates GraphQL-like schema for your project.
+  - `docusaurus`
+    Generates Docusaurus markdown for your project.
+  - `jsdoc`
+    Generates JSDoc markdown for your project.
+
+#### Options
+- `-m, --manifest-file <path>`
+  Specify your project's manifest file.
+  By default, `docgen` searches for `polywrap.yaml`.
+
+- `-g, --docgen-dir <path>`
+  Specify the output directory for generated docs.
+  By default, `./docs` is used.
+
+- `-c, --client-config <config-path>`
+  Use a custom Polywrap Client configuration.
+
+- `--wrapper-envs <envs-path>`
+  Configure wrapper environment values using the provided file.
+
+- `-i, --imports`
+  Generate docs for your project's dependencies as well.
+
+### `manifest | m`
+
+Inspect and migrate Polywrap manifests.
+
+#### Subcommands
+
+#### `schema | s`
+
+Output the schema for any of your Project or Extension manifests. 
+
+Usage:
+```bash
+# Output schema for the current project manifest (polywrap.yaml)
+polywrap manifest schema
+```
+
+##### Arguments
+
+- `type`
+  The type of the manifest file. The default value for `type` is `project`.
+  
+##### Options
+
+- `-r, --raw`
+  Output the full JSON Schema for the given manifest.
+  
+- `-m, --manifest-file <path>`
+  The manifest file for which the schema will be rendered. The `type` argument determines the default manifest file used.
+  For example, `polywrap manifest schema build` will use `polywrap.build.yaml` as its default manifest file.
+
+#### `migrate | m`
+
+Migrate a Project or Extension manifest file to the the latest version, or a version specified.
+
+Usage:
+```bash
+# Migrate the current project manifest (polywrap.yaml)
+polywrap manifest migrate
+```
+##### Arguments
+
+- `type`
+  The type of the manifest file. The default value for `type` is `project`.
+
+##### Options
+- `-f, --format <format>`
+  Migrate to a specific format instead of the latest.
+  
+  Example:
+  ```bash
+  # Migrate the current project manfiest to format 0.2.0
+  polywrap manifest migrate -f 0.2.0
+  # or
+  polywrap m m -f 0.2.0
+  ```
+
+- `-m, --manifest-file <path>`
+  The manifest file for which the schema will be rendered. The `type` argument determines the default manifest file used.
+  For example, `polywrap manifest migrate build` will use `polywrap.build.yaml` as its default manifest file.
+  
+  Example:
+  ```bash
+  # Migrate "custom-manifest.yaml" to the latest format
+  polywrap manifest migrate -m custom-manifest.yaml
+  # or
+  polywrap m m -m custom-manifest.yaml
+  ```
+
+### The `-c, --client-config` option
+
+The `build`, `codegen`, `docgen` and `test` commands allow the user to configure the Polywrap Client via the `-c, --client-config <config-path>` option.
+
+You can supply a path to a Javascript or Typescript module which exports a function named `getClientConfig`:
+
+```typescript
+// asynchronous option
+export async function getClientConfig(
+  defaultConfigs: Partial<PolywrapClientConfig>
+): Promise<Partial<PolywrapClientConfig>>
+
+// synchronous option
+export function getClientConfig(
+  defaultConfigs: Partial<PolywrapClientConfig>
+): Partial<PolywrapClientConfig>
+```
+
+### The `--wrapper-envs` option
+All commands which support the `-c, --client-config` option also support the `--wrapper-envs <envs-path>` option.
+This option allows the user to set environment values for Wrappers using a simple YAML or JSON file.
+
+For example, if you would like to change the API key used within the Ethereum plugin wrapper, you can create a `envs.yaml` file:
+
+```yaml
+ens/ethereum.polywrap.eth:
+  connection:
+    node: https://mainnet.infura.io/v3/YOUR_API_KEY # Use Infura with your API key
+    networkNameOrChainId: mainnet
+```
+
+You can then run the `build`, `codegen`, `docgen` and `test` and specify your custom `--wrapper-envs`:
+
+```bash
+polywrap codegen --wrapper-envs envs.yaml
+```
+
+You can also pass environment variables into the wrappper-envs file by using `$`:
+
+```yaml
+ens/ethereum.polywrap.eth:
+  connection:
+    node: $MY_INFURA_NODE # Use environment variable called MY_INFURA_NODE
+    networkNameOrChainId: mainnet
+```
+
+If you need to use the `$` sign within your wrapper-envs file, you can escape it using `$$`.
+
+## Logging
+
+By default, the Polywrap CLI outputs all of its messages to the console.
+
+### Logging levels
+Different levels of output verbosity are supported by using the following options:
+
+- `-v, --verbose`
+  Enables logging of informational messages in addition to standard output.
+
+- `-q, --quiet`
+  Disables ALL logging. Overrides the `--verbose` option.
+
+### Logging to a file
+You can also tell the Polywrap CLI to save its output to a logfile using the `-l, --log-file [path]` option.
+
+Specifying the `-l` option without a `path` parameter will create a log file within the `./.polywrap/logs` directory.
+
+```bash
+# Output will be saved to the "./.polywrap/logs" directory
+polywrap codegen -l
+```
+
+Alternatively, you can specify your own log file path.
+
+```bash
+# Output will be saved to "my-log-file.log"
+polywrap codegen -l my-log-file.log
 ```

--- a/src/docs/reference/clients/js/client-js.md
+++ b/src/docs/reference/clients/js/client-js.md
@@ -3,31 +3,417 @@ id: client-js
 title: Client
 ---
 
+# @polywrap/client-js
 <a href="https://www.npmjs.com/package/@polywrap/client-js" target="_blank" rel="noopener noreferrer">
 <img src="https://img.shields.io/npm/v/@polywrap/client-js.svg" alt="npm"/>
 </a>
 
 <br/>
 <br/>
-
-The Polywrap JavaScript client exists to help developers integrate wrappers into their applications. It's designed to run in any environment that can execute JavaScript (think websites, node scripts, etc.).
+The Polywrap JavaScript client invokes functions of wrappers and plugins. It's designed to run in any environment that can execute JavaScript (think websites, node scripts, etc.). It has TypeScript support.
 
 ## Installation
 
 ```bash
-npm install @polywrap/client-js
+npm install --save @polywrap/client-js
 ```
 
 ## Usage
 
-Use an `import` or `require` statement, depending on which your environment supports.
+### Instantiate the client
+```ts
+import { PolywrapClient } from "@polywrap/client-js";
 
-```js
-$snippet: js-import-client
+const client = new PolywrapClient();
 ```
 
-Then, you will be able to use the `PolywrapClient` like so:
+### Invoke a wrapper
 
-```js
-$snippet: js-client-invoke
+```ts
+await client.invoke({
+  uri: "ens/rinkeby/helloworld.dev.polywrap.eth",
+  method: "logMessage",
+  args: {
+    message: "Hello World!"
+  }
+});
+```
+
+### Configure the client
+
+```ts
+const config = {
+  // redirect queries from one uri to another
+  redirects: [
+    {
+      from: "wrap://ens/from.eth",
+      to: "wrap://ens/to.eth",
+    }
+  ],
+  // declare and configure plugin wrappers
+  plugins: [
+    {
+      uri: "wrap://ens/ipfs.polywrap.eth",
+      plugin: ipfsPlugin({}),
+    },
+  ],
+  // declare interface implementations
+  interfaces: [
+    {
+      interface: "wrap://ens/uri-resolver.core.polywrap.eth",
+      implementations: [
+        "wrap://ens/ipfs-resolver.polywrap.eth",
+      ],
+    },
+  ],
+  // set environmental variables for a wrapper
+  envs: [
+    {
+      uri: "wrap://ens/ipfs.polywrap.eth",
+      env: {
+        provider: "https://ipfs.wrappers.io",
+      },
+    },
+  ],
+  
+  // ADVANCED USAGE:
+  
+  // customize URI resolution
+  resolver: new RecursiveResolver(
+    new PackageToWrapperCacheResolver(wrapperCache, [
+      new LegacyRedirectsResolver(),
+      new LegacyPluginsResolver(),
+      new ExtendableUriResolver(),
+    ])
+  ),
+
+  // custom wrapper cache
+  wrapperCache: new WrapperCache(),
+  
+  // tracer configuration - see @polywrap/tracing-js package
+  tracerConfig: { ... },
+};
+```
+```ts
+// create a client by modifying the default configuration bundle
+const client = new PolywrapClient(config);
+
+// or remove and replace the default configuration
+const altClient = new PolywrapClient(config, { noDefaults: true });
+```
+
+## Reference
+
+### Constructor
+```ts
+/**
+ * Instantiate a PolywrapClient
+ *
+ * @param config - a whole or partial client configuration
+ * @param options - { noDefaults?: boolean }
+ */
+constructor(config?: Partial<PolywrapClientConfig<string | Uri>>, options?: {
+  noDefaults?: boolean;
+});
+```
+
+### getConfig
+```ts
+/**
+ * Returns the configuration used to instantiate the client
+ *
+ * @returns an immutable Polywrap client config
+ */
+getConfig(): PolywrapClientConfig<Uri>;
+```
+
+### setTracingEnabled
+```ts
+/**
+ * Enable tracing for intricate debugging
+ *
+ * @remarks
+ * Tracing uses the @polywrap/tracing-js package
+ *
+ * @param tracerConfig - configure options such as the tracing level
+ * @returns void
+ */
+setTracingEnabled(tracerConfig?: Partial<TracerConfig>): void;
+```
+
+### getRedirects
+```ts
+/**
+ * returns all uri redirects from the configuration used to instantiate the client
+ *
+ * @returns an array of uri redirects
+ */
+getRedirects(): readonly UriRedirect<Uri>[];
+```
+
+### getPlugins
+```ts
+/**
+ * returns all plugin registrations from the configuration used to instantiate the client
+ *
+ * @returns an array of plugin registrations
+ */
+getPlugins(): readonly PluginRegistration<Uri>[];
+```
+
+### getPluginByUri
+```ts
+/**
+ * returns a plugin package from the configuration used to instantiate the client
+ *
+ * @param uri - the uri used to register the plugin
+ * @returns a plugin package, or undefined if a plugin is not found at the given uri
+ */
+getPluginByUri<TUri extends Uri | string>(uri: TUri): PluginPackage<unknown> | undefined;
+```
+
+### getInterfaces
+```ts
+/**
+ * returns all interfaces from the configuration used to instantiate the client
+ *
+ * @returns an array of interfaces and their registered implementations
+ */
+getInterfaces(): readonly InterfaceImplementations<Uri>[];
+```
+
+### getEnvs
+```ts
+/**
+ * returns all env registrations from the configuration used to instantiate the client
+ *
+ * @returns an array of env objects containing wrapper environmental variables
+ */
+getEnvs(): readonly Env<Uri>[];
+```
+
+### getUriResolver
+```ts
+/**
+ * returns the URI resolver from the configuration used to instantiate the client
+ *
+ * @returns an object that implements the IUriResolver interface
+ */
+getUriResolver(): IUriResolver<unknown>;
+```
+
+### getEnvByUri
+```ts
+/**
+ * returns an env (a set of environmental variables) from the configuration used to instantiate the client
+ *
+ * @param uri - the URI used to register the env
+ * @returns an env, or undefined if an env is not found at the given URI
+ */
+getEnvByUri<TUri extends Uri | string>(uri: TUri): Env<Uri> | undefined;
+```
+
+### getManifest
+```ts
+/**
+ * returns a package's wrap manifest
+ *
+ * @param uri - a wrap URI
+ * @param options - { noValidate?: boolean }
+ * @returns a Result containing the WrapManifest if the request was successful
+ */
+getManifest<TUri extends Uri | string>(uri: TUri, options?: GetManifestOptions): Promise<Result<WrapManifest, Error>>;
+```
+
+### getFile
+```ts
+/**
+ * returns a file contained in a wrap package
+ *
+ * @param uri - a wrap URI
+ * @param options - { path: string; encoding?: "utf-8" | string }
+ * @returns a Promise of a Result containing a file if the request was successful
+ */
+getFile<TUri extends Uri | string>(uri: TUri, options: GetFileOptions): Promise<Result<string | Uint8Array, Error>>;
+```
+
+### getImplementations
+```ts
+/**
+ * returns the interface implementations associated with an interface URI
+ *  from the configuration used to instantiate the client
+ *
+ * @param uri - a wrap URI
+ * @param options - { applyRedirects?: boolean }
+ * @returns a Result containing URI array if the request was successful
+ */
+getImplementations<TUri extends Uri | string>(uri: TUri, options?: GetImplementationsOptions): Result<TUri[], Error>;
+```
+
+### query
+```ts
+/**
+ * Invoke a wrapper using GraphQL query syntax
+ *
+ * @remarks
+ * This method behaves similar to the invoke method and allows parallel requests,
+ * but the syntax is more verbose. If the query is successful, data will be returned
+ * and the `error` value of the returned object will be undefined. If the query fails,
+ * the data property will be undefined and the error property will be populated.
+ *
+ * @param options - {
+ *   // The Wrapper's URI
+ *   uri: TUri;
+ *
+ *   // The GraphQL query to parse and execute, leading to one or more Wrapper invocations.
+ *   query: string | QueryDocument;
+ *
+ *   // Variables referenced within the query string via GraphQL's '$variable' syntax.
+ *   variables?: TVariables;
+ * }
+ *
+ * @returns A Promise containing an object with either the data or an error
+ */
+query<TData extends Record<string, unknown> = Record<string, unknown>, TVariables extends Record<string, unknown> = Record<string, unknown>, TUri extends Uri | string = string>(options: QueryOptions<TVariables, TUri>): Promise<QueryResult<TData>>;
+```
+
+### invokeWrapper
+```ts
+/**
+ * Invoke a wrapper using standard syntax and an instance of the wrapper
+ *
+ * @param options - {
+ *   // The Wrapper's URI
+ *   uri: TUri;
+ *
+ *   // Method to be executed.
+ *   method: string;
+ *
+ *   //Arguments for the method, structured as a map, removing the chance of incorrectly ordering arguments.
+ *    args?: Record<string, unknown> | Uint8Array;
+ *
+ *   // Env variables for the wrapper invocation.
+ *    env?: Record<string, unknown>;
+ *
+ *   resolutionContext?: IUriResolutionContext;
+ *
+ *   // if true, return value is a msgpack-encoded byte array
+ *   encodeResult?: boolean;
+ * }
+ *
+ * @returns A Promise with a Result containing the return value or an error
+ */
+invokeWrapper<TData = unknown, TUri extends Uri | string = string>(options: InvokerOptions<TUri> & {
+    wrapper: Wrapper;
+}): Promise<InvokeResult<TData>>;
+```
+
+### invoke
+```ts
+/**
+ * Invoke a wrapper using standard syntax.
+ * Unlike `invokeWrapper`, this method automatically retrieves and caches the wrapper.
+ *
+ * @param options - {
+ *   // The Wrapper's URI
+ *   uri: TUri;
+ *
+ *   // Method to be executed.
+ *   method: string;
+ *
+ *   //Arguments for the method, structured as a map, removing the chance of incorrectly ordering arguments.
+ *    args?: Record<string, unknown> | Uint8Array;
+ *
+ *   // Env variables for the wrapper invocation.
+ *    env?: Record<string, unknown>;
+ *
+ *   resolutionContext?: IUriResolutionContext;
+ *
+ *   // if true, return value is a msgpack-encoded byte array
+ *   encodeResult?: boolean;
+ * }
+ *
+ * @returns A Promise with a Result containing the return value or an error
+ */
+invoke<TData = unknown, TUri extends Uri | string = string>(options: InvokerOptions<TUri>): Promise<InvokeResult<TData>>;
+```
+
+### subscribe
+```ts
+/**
+ * Invoke a wrapper at a regular frequency (within ~16ms)
+ *
+ * @param options - {
+ *   // The Wrapper's URI
+ *   uri: TUri;
+ *
+ *   // Method to be executed.
+ *   method: string;
+ *
+ *   //Arguments for the method, structured as a map, removing the chance of incorrectly ordering arguments.
+ *    args?: Record<string, unknown> | Uint8Array;
+ *
+ *   // Env variables for the wrapper invocation.
+ *    env?: Record<string, unknown>;
+ *
+ *   resolutionContext?: IUriResolutionContext;
+ *
+ *   // if true, return value is a msgpack-encoded byte array
+ *   encodeResult?: boolean;
+ *
+ *   // the frequency at which to perform the invocation
+ *   frequency?: {
+ *     ms?: number;
+ *     sec?: number;
+ *     min?: number;
+ *     hours?: number;
+ *   }
+ * }
+ *
+ * @returns A Promise with a Result containing the return value or an error
+ */
+subscribe<TData = unknown, TUri extends Uri | string = string>(options: SubscribeOptions<TUri>): Subscription<TData>;
+```
+
+### tryResolveUri
+```ts
+/**
+ * Resolve a URI to a wrap package, a wrapper, or a uri
+ *
+ * @param options - { uri: TUri; resolutionContext?: IUriResolutionContext }
+ * @returns A Promise with a Result containing either a wrap package, a wrapper, or a URI if successful
+ */
+tryResolveUri<TUri extends Uri | string>(options: TryResolveUriOptions<TUri>): Promise<Result<UriPackageOrWrapper, unknown>>;
+```
+
+### loadWrapper
+```ts
+/**
+ * Resolve a URI to a wrap package or wrapper.
+ * If the URI resolves to wrap package, load the wrapper.
+ *
+ * @remarks
+ * Unlike other methods, `loadWrapper` does not accept a string URI.
+ * You can create a Uri (from the `@polywrap/core-js` package) using `Uri.from("wrap://...")`
+ *
+ * @param uri: the Uri to resolve
+ * @param resolutionContext? a resolution context
+ * @param options - { noValidate?: boolean }
+ * @returns A Promise with a Result containing either a wrapper if successful
+ */
+loadWrapper(uri: Uri, resolutionContext?: IUriResolutionContext, options?: DeserializeManifestOptions): Promise<Result<Wrapper, Error>>;
+```
+
+## Development
+
+The Polywrap JavaScript client is open-source. It lives within the [Polywrap toolchain monorepo](https://github.com/polywrap/toolchain/tree/origin/packages/js/client). Contributions from the community are welcomed!
+
+### Build
+```bash
+nvm use && yarn install && yarn build
+```
+
+### Test
+```bash
+yarn test
 ```

--- a/yarn.lock
+++ b/yarn.lock
@@ -5085,10 +5085,10 @@ dns-txt@^2.0.2:
   dependencies:
     buffer-indexof "^1.0.0"
 
-doc-snippets@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/doc-snippets/-/doc-snippets-0.2.0.tgz#6250a881f8b22e8a58514767102cf270641ee588"
-  integrity sha512-AqLd1FmMlinKKoA9FR9kr4Z2TCcexCdCCFcuNijNxTKpryghZNkhcIvkG44T/99Fmu/eq3OLKv7eG/vKAiDlFg==
+doc-snippets@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/doc-snippets/-/doc-snippets-0.3.0.tgz#69c3739e7ee296f4c507adbaa9581c6d3c8a35d5"
+  integrity sha512-PUeDuNTfQ6xyO2JOU/B7wT6ThaEiqwG1wlbaEoYULRXP5U2PDefqOymg7JamORmW69yV+lCIB8JV5MYzKLBTpg==
   dependencies:
     commander "^9.4.1"
     fs-extra "^10.1.0"
@@ -10456,6 +10456,13 @@ reading-time@^1.3.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/reading-time/-/reading-time-1.5.0.tgz#d2a7f1b6057cb2e169beaf87113cc3411b5bc5bb"
   integrity sha512-onYyVhBNr4CmAxFsKS7bz+uTLRakypIe4R+5A824vBSkQy/hB3fZepoVEf8OVAxzLvK+H/jm9TzpI3ETSm64Kg==
+
+readme-to-doc@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/readme-to-doc/-/readme-to-doc-0.0.2.tgz#b2590efaa5fdf4748ba5bd14bd12fa8f1d0f4753"
+  integrity sha512-88j27QuXI9qbiGrCKOUuJLkovHXoKnsdpy5kErKkJgE+EsIQmotn8sTZDQXJfKn24Htr+jSpYIbDnjM/vUNN8Q==
+  dependencies:
+    commander "^9.4.1"
 
 rechoir@^0.6.2:
   version "0.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10476,13 +10476,6 @@ reading-time@^1.3.0:
   resolved "https://registry.yarnpkg.com/reading-time/-/reading-time-1.5.0.tgz#d2a7f1b6057cb2e169beaf87113cc3411b5bc5bb"
   integrity sha512-onYyVhBNr4CmAxFsKS7bz+uTLRakypIe4R+5A824vBSkQy/hB3fZepoVEf8OVAxzLvK+H/jm9TzpI3ETSm64Kg==
 
-readme-to-doc@^0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/readme-to-doc/-/readme-to-doc-0.0.2.tgz#b2590efaa5fdf4748ba5bd14bd12fa8f1d0f4753"
-  integrity sha512-88j27QuXI9qbiGrCKOUuJLkovHXoKnsdpy5kErKkJgE+EsIQmotn8sTZDQXJfKn24Htr+jSpYIbDnjM/vUNN8Q==
-  dependencies:
-    commander "^9.4.1"
-
 rechoir@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"


### PR DESCRIPTION
I added two scripts. One clones repos. The other copies readmes from the clone directories, adds docusaurus headers, places them in the reference doc folders.

To add new repos to clone, you can update this:
```typescript
type Repo = {
  org?: string; // defaults to "polywrap"
  name: string;
  branch: string;
}

const repos: Repo[] = [
  {
    name: "toolchain",
    branch: "origin"
  }
]
```

To add new readme -> doc transformations, you can update this:

```typescript
// paths are relative to clone and reference doc dirs
const readmeToDocPaths: Record<string, string> = {
  "./polywrap/toolchain/packages/js/client/README.md": "./clients/js/client-js.md",
  "./polywrap/toolchain/packages/cli/README.md": "./cli/polywrap-cli.md"
}
```

Feedback welcome!

Closes https://github.com/polywrap/documentation/issues/230